### PR TITLE
Agrego excepcion log_config

### DIFF
--- a/consulterscommons/log_tools/prefect_log_config.py
+++ b/consulterscommons/log_tools/prefect_log_config.py
@@ -175,7 +175,9 @@ class PrefectLogger(object):
                 self._run_name = actual_run_name
                 self._logger_prefect = self._initialize_logger()
 
-        return self._logger_prefect
+            return self._logger_prefect
+        else:
+            raise ValueError("No se pudo obtener el nombre del flujo o tarea. Verifique que se esta intentando obtener el logger desde un flujo o tarea de Prefect.")
 
     def cambiar_rotfile_handler_params(self, log_path: str = DEFAULT_LOG_PATH,
                                     when: str = DEFAULT_WHEN,


### PR DESCRIPTION
The commit in this pull request fixes an issue where the `log_config` function was being called from a function that is not a flow or task. The commit adds an exception to prevent this and raises a `ValueError` with a descriptive error message if the logger is not being obtained from a Prefect flow or task.